### PR TITLE
Add MIT License and update README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 avanimathur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project is a Java-based implementation of Git, developed as part of the "Build Your Own Git" challenge by [Codecrafters](https://codecrafters.io). This project aims to deepen understanding of Git's internal mechanics by recreating some of its core functionalities from scratch.
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 ## Features
 
 - **Repository Initialization**: Initialize a new Git repository.
@@ -18,6 +20,8 @@ This project is a Java-based implementation of Git, developed as part of the "Bu
    git clone https://github.com/avanimathur/Build-your-own-Git-opensource.git
    cd Git-CodeCrafter
 
+   ```
+
 Sample Commands :
 
 ```bash
@@ -27,12 +31,19 @@ javac src/main/java/Main.java
 ```bash
 javac -d out src/main/java/Main.java
 ```
+
 ```bash
 java -cp out src/Main/java/Main.java init
 ```
+
 ```bash
 java -cp out src/Main/java/Main.java cat-file -p <commit_hash>
 ```
+
 ```bash
 java -cp out src/Main/java/Main.java ls-tree --name-only <commit_hash>
 ```
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
Closes #6 

Added the MIT License to the project.

I chose the MIT License because it is one of the most widely used and easy-to-understand open-source licenses. It allows anyone to freely use, modify, and distribute the code, whether for personal or commercial purposes, as long as the original license and copyright notice are included.

This promotes open collaboration while still protecting the original work. The simplicity and permissiveness of the MIT License make it a great fit for this project.
