### PR TITLE
Add support for initial commits in commit-tree without requiring -p argument

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -88,13 +88,13 @@ public class Main {
                 cloneRepository(args);
                 break;
           }
-            // case "add" ->{
-            //     if (args.length < 2) {
-            //         System.out.println("Usage: java Main add <file>");
-            //     } else {
-            //         addToIndex(args[1]);
-            //     }
-            // }
+            case "add" ->{
+                if (args.length < 2) {
+                    System.out.println("Usage: java Main add <file>");
+                } else {
+                    addToIndex(args[1]);
+                }
+            }
 
             default -> System.out.println("Unknown command: " + command);
         }
@@ -410,48 +410,48 @@ public static void cloneRepository(String[] args) throws IOException {
     }
   }
 
-//   public static void addToIndex(String filePath) throws IOException {
-//     File file = new File(filePath);
-//     if (!file.exists()) {
-//         System.out.println("File not found: " + filePath);
-//         return;
-//     }
+  public static void addToIndex(String filePath) throws IOException {
+    File file = new File(filePath);
+    if (!file.exists()) {
+        System.out.println("File not found: " + filePath);
+        return;
+    }
 
-//     // Step 1: Read file content
-//     byte[] fileContents = Files.readAllBytes(file.toPath());
-//     String header = "blob " + fileContents.length + "\0";
-//     byte[] headerBytes = header.getBytes(StandardCharsets.UTF_8);
-//     byte[] fullContent = new byte[headerBytes.length + fileContents.length];
-//     System.arraycopy(headerBytes, 0, fullContent, 0, headerBytes.length);
-//     System.arraycopy(fileContents, 0, fullContent, headerBytes.length, fileContents.length);
+    // Step 1: Read file content
+    byte[] fileContents = Files.readAllBytes(file.toPath());
+    String header = "blob " + fileContents.length + "\0";
+    byte[] headerBytes = header.getBytes(StandardCharsets.UTF_8);
+    byte[] fullContent = new byte[headerBytes.length + fileContents.length];
+    System.arraycopy(headerBytes, 0, fullContent, 0, headerBytes.length);
+    System.arraycopy(fileContents, 0, fullContent, headerBytes.length, fileContents.length);
 
-//     // Step 2: Hash content and save blob
-//     String sha1 = sha1Hex(fullContent); // Already defined in your file
-//     String dir = sha1.substring(0, 2);
-//     String fileSha = sha1.substring(2);
-//     File blobFile = new File(".git/objects/" + dir + "/" + fileSha);
-//     blobFile.getParentFile().mkdirs();
+    // Step 2: Hash content and save blob
+    String sha1 = sha1Hex(fullContent); // Already defined in your file
+    String dir = sha1.substring(0, 2);
+    String fileSha = sha1.substring(2);
+    File blobFile = new File(".git/objects/" + dir + "/" + fileSha);
+    blobFile.getParentFile().mkdirs();
 
-//     try (DeflaterOutputStream out = new DeflaterOutputStream(new FileOutputStream(blobFile))) {
-//         out.write(fullContent);
-//     }
+    try (DeflaterOutputStream out = new DeflaterOutputStream(new FileOutputStream(blobFile))) {
+        out.write(fullContent);
+    }
 
-//     // Step 3: Update .git/index
-//     File indexFile = new File(".git/index");
-//     indexFile.getParentFile().mkdirs();
-//     List<String> index = new ArrayList<>();
+    // Step 3: Update .git/index
+    File indexFile = new File(".git/index");
+    indexFile.getParentFile().mkdirs();
+    List<String> index = new ArrayList<>();
 
-//     if (indexFile.exists()) {
-//         index = Files.readAllLines(indexFile.toPath());
-//         index = index.stream()
-//                 .filter(line -> !line.startsWith(filePath + " "))
-//                 .collect(Collectors.toList());
-//     }
+    if (indexFile.exists()) {
+        index = Files.readAllLines(indexFile.toPath());
+        index = index.stream()
+                .filter(line -> !line.startsWith(filePath + " "))
+                .collect(Collectors.toList());
+    }
 
-//     index.add(filePath + " " + sha1);
-//     Files.write(indexFile.toPath(), index);
-//     System.out.println("Staged: " + filePath);
-// }
+    index.add(filePath + " " + sha1);
+    Files.write(indexFile.toPath(), index);
+    System.out.println("Staged: " + filePath);
+}
 
 
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -7,11 +7,8 @@ import java.security.MessageDigest; // Handling file paths
 import java.security.NoSuchAlgorithmException; // Path manipulations
 import java.time.Instant; // For hashing (like Git)
 import java.util.*;
-import java.util.stream.Collectors; // Handling timestamps
-import java.util.zip.DeflaterOutputStream;
-import java.util.zip.InflaterInputStream;
-
-
+import java.util.zip.DeflaterOutputStream; // Handling hashing errors
+import java.util.zip.InflaterInputStream; // Handling timestamps
 
 public class Main {
     public static void main(String[] args) throws IOException { 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,14 +1,24 @@
-import java.io.*;  // For file handling and input-output operations
-import java.nio.charset.StandardCharsets; // For making API requests
-import java.nio.file.Files; // For URL handling
-import java.nio.file.Path; // Encoding support
-import java.nio.file.Paths; // File reading/writing
-import java.security.MessageDigest; // Handling file paths
-import java.security.NoSuchAlgorithmException; // Path manipulations
-import java.time.Instant; // For hashing (like Git)
-import java.util.*;
-import java.util.zip.DeflaterOutputStream; // Handling hashing errors
-import java.util.zip.InflaterInputStream; // Handling timestamps
+import java.io.ByteArrayOutputStream;  // For file handling and input-output operations
+import java.io.DataInputStream; // For making API requests
+import java.io.File; // For URL handling
+import java.io.FileInputStream; // Encoding support
+import java.io.FileOutputStream; // File reading/writing
+import java.io.IOException; // Handling file paths
+import java.io.UncheckedIOException; // Path manipulations
+import java.nio.charset.StandardCharsets; // For hashing (like Git)
+import java.nio.file.Files;
+import java.nio.file.Path; // Handling hashing errors
+import java.nio.file.Paths; // Handling timestamps
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Scanner;
+import java.util.stream.Collectors;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
 
 public class Main {
     public static void main(String[] args) throws IOException { 
@@ -88,13 +98,13 @@ public class Main {
                 cloneRepository(args);
                 break;
           }
-            case "add" ->{
-                if (args.length < 2) {
-                    System.out.println("Usage: java Main add <file>");
-                } else {
-                    addToIndex(args[1]);
-                }
-            }
+            // case "add" ->{
+            //     if (args.length < 2) {
+            //         System.out.println("Usage: java Main add <file>");
+            //     } else {
+            //         addToIndex(args[1]);
+            //     }
+            // }
 
             default -> System.out.println("Unknown command: " + command);
         }
@@ -410,7 +420,7 @@ public static void cloneRepository(String[] args) throws IOException {
     }
   }
 
-  public static void addToIndex(String filePath) throws IOException {
+  /*public static void addToIndex(String filePath) throws IOException {
     File file = new File(filePath);
     if (!file.exists()) {
         System.out.println("File not found: " + filePath);
@@ -451,7 +461,7 @@ public static void cloneRepository(String[] args) throws IOException {
     index.add(filePath + " " + sha1);
     Files.write(indexFile.toPath(), index);
     System.out.println("Staged: " + filePath);
-}
+} */
 
 
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,19 +1,15 @@
 import java.io.*;  // For file handling and input-output operations
-import java.net.HttpURLConnection; // For making API requests
-import java.net.URL; // For URL handling
-import java.nio.charset.StandardCharsets; // Encoding support
-import java.nio.file.Files; // File reading/writing
-import java.nio.file.Path; // Handling file paths
-import java.nio.file.Paths; // Path manipulations
-import java.security.MessageDigest; // For hashing (like Git)
-import java.security.NoSuchAlgorithmException; // Handling hashing errors
-import java.time.Instant; // Handling timestamps
-import java.util.*; // Data structures like List, Map, Scanner
-import java.util.zip.DeflaterOutputStream; // For compression (like Git blobs)
-import java.util.zip.InflaterInputStream; // For decompression
-import java.net.http.HttpClient; // For modern HTTP requests
-import java.net.http.HttpRequest; // For building HTTP requests
-import java.net.http.HttpResponse; // Handling HTTP responses
+import java.nio.charset.StandardCharsets; // For making API requests
+import java.nio.file.Files; // For URL handling
+import java.nio.file.Path; // Encoding support
+import java.nio.file.Paths; // File reading/writing
+import java.security.MessageDigest; // Handling file paths
+import java.security.NoSuchAlgorithmException; // Path manipulations
+import java.time.Instant; // For hashing (like Git)
+import java.util.*;
+import java.util.stream.Collectors; // Handling hashing errors
+import java.util.zip.DeflaterOutputStream; // Handling timestamps
+import java.util.zip.InflaterInputStream; // Data structures like List, Map, Scanner
 
 public class Main {
     public static void main(String[] args) throws IOException { 
@@ -45,27 +41,61 @@ public class Main {
                 break;
             }
 
+            // case "commit-tree" -> {
+            //     if (args.length < 6) {
+            //         throw new IllegalArgumentException(
+            //             "Usage: java Main commit-tree <tree> -p <parent> -m <message>");
+            //     }
+            //     String treeHash = args[1];
+            //     String parentHash = args[3];
+            //     String message = args[5];
+            //     String commitHash = commitTreeHandler(treeHash, parentHash, message);
+            //     System.out.println(commitHash);
+            //     break;
+            // }
+
             case "commit-tree" -> {
-                if (args.length < 6) {
+                if (args.length < 3) {
                     throw new IllegalArgumentException(
-                        "Usage: java Main commit-tree <tree> -p <parent> -m <message>");
+                        "Usage: java Main commit-tree <tree> [-p <parent>] -m <message>");
                 }
+
                 String treeHash = args[1];
-                String parentHash = args[3];
-                String message = args[5];
+                String parentHash = null;
+                String message = null;
+
+                for (int i = 2; i < args.length; i++) {
+                    switch (args[i]) {
+                        case "-p" -> parentHash = args[++i];
+                        case "-m" -> message = args[++i];
+                    }
+                }
+
+                if (message == null) {
+                    throw new IllegalArgumentException("Commit message is required with -m");
+                }
+
                 String commitHash = commitTreeHandler(treeHash, parentHash, message);
                 System.out.println(commitHash);
                 break;
             }
+
             
-          case "clone" -> {
-            if (args.length != 3) {
-              throw new IllegalArgumentException(
-                  "Usage: java Main clone <repository-url> <target-directory>");
-            }
-            cloneRepository(args);
-            break;
+            case "clone" -> {
+                if (args.length != 3) {
+                throw new IllegalArgumentException(
+                    "Usage: java Main clone <repository-url> <target-directory>");
+                }
+                cloneRepository(args);
+                break;
           }
+            case "add" ->{
+                if (args.length < 2) {
+                    System.out.println("Usage: java Main add <file>");
+                } else {
+                    addToIndex(args[1]);
+                }
+            }
 
             default -> System.out.println("Unknown command: " + command);
         }
@@ -380,5 +410,49 @@ public static void cloneRepository(String[] args) throws IOException {
       throw new RuntimeException("Cloning process was interrupted.", e);
     }
   }
+
+  public static void addToIndex(String filePath) throws IOException {
+    File file = new File(filePath);
+    if (!file.exists()) {
+        System.out.println("File not found: " + filePath);
+        return;
+    }
+
+    // Step 1: Read file content
+    byte[] fileContents = Files.readAllBytes(file.toPath());
+    String header = "blob " + fileContents.length + "\0";
+    byte[] headerBytes = header.getBytes(StandardCharsets.UTF_8);
+    byte[] fullContent = new byte[headerBytes.length + fileContents.length];
+    System.arraycopy(headerBytes, 0, fullContent, 0, headerBytes.length);
+    System.arraycopy(fileContents, 0, fullContent, headerBytes.length, fileContents.length);
+
+    // Step 2: Hash content and save blob
+    String sha1 = sha1Hex(fullContent); // Already defined in your file
+    String dir = sha1.substring(0, 2);
+    String fileSha = sha1.substring(2);
+    File blobFile = new File(".git/objects/" + dir + "/" + fileSha);
+    blobFile.getParentFile().mkdirs();
+
+    try (DeflaterOutputStream out = new DeflaterOutputStream(new FileOutputStream(blobFile))) {
+        out.write(fullContent);
+    }
+
+    // Step 3: Update .git/index
+    File indexFile = new File(".git/index");
+    indexFile.getParentFile().mkdirs();
+    List<String> index = new ArrayList<>();
+
+    if (indexFile.exists()) {
+        index = Files.readAllLines(indexFile.toPath());
+        index = index.stream()
+                .filter(line -> !line.startsWith(filePath + " "))
+                .collect(Collectors.toList());
+    }
+
+    index.add(filePath + " " + sha1);
+    Files.write(indexFile.toPath(), index);
+    System.out.println("Staged: " + filePath);
+}
+
 
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -7,8 +7,11 @@ import java.security.MessageDigest; // Handling file paths
 import java.security.NoSuchAlgorithmException; // Path manipulations
 import java.time.Instant; // For hashing (like Git)
 import java.util.*;
-import java.util.zip.DeflaterOutputStream; // Handling hashing errors
-import java.util.zip.InflaterInputStream; // Handling timestamps
+import java.util.stream.Collectors; // Handling timestamps
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
+
+
 
 public class Main {
     public static void main(String[] args) throws IOException { 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -7,9 +7,8 @@ import java.security.MessageDigest; // Handling file paths
 import java.security.NoSuchAlgorithmException; // Path manipulations
 import java.time.Instant; // For hashing (like Git)
 import java.util.*;
-import java.util.stream.Collectors; // Handling hashing errors
-import java.util.zip.DeflaterOutputStream; // Handling timestamps
-import java.util.zip.InflaterInputStream; // Data structures like List, Map, Scanner
+import java.util.zip.DeflaterOutputStream; // Handling hashing errors
+import java.util.zip.InflaterInputStream; // Handling timestamps
 
 public class Main {
     public static void main(String[] args) throws IOException { 
@@ -89,13 +88,13 @@ public class Main {
                 cloneRepository(args);
                 break;
           }
-            case "add" ->{
-                if (args.length < 2) {
-                    System.out.println("Usage: java Main add <file>");
-                } else {
-                    addToIndex(args[1]);
-                }
-            }
+            // case "add" ->{
+            //     if (args.length < 2) {
+            //         System.out.println("Usage: java Main add <file>");
+            //     } else {
+            //         addToIndex(args[1]);
+            //     }
+            // }
 
             default -> System.out.println("Unknown command: " + command);
         }
@@ -411,48 +410,48 @@ public static void cloneRepository(String[] args) throws IOException {
     }
   }
 
-  public static void addToIndex(String filePath) throws IOException {
-    File file = new File(filePath);
-    if (!file.exists()) {
-        System.out.println("File not found: " + filePath);
-        return;
-    }
+//   public static void addToIndex(String filePath) throws IOException {
+//     File file = new File(filePath);
+//     if (!file.exists()) {
+//         System.out.println("File not found: " + filePath);
+//         return;
+//     }
 
-    // Step 1: Read file content
-    byte[] fileContents = Files.readAllBytes(file.toPath());
-    String header = "blob " + fileContents.length + "\0";
-    byte[] headerBytes = header.getBytes(StandardCharsets.UTF_8);
-    byte[] fullContent = new byte[headerBytes.length + fileContents.length];
-    System.arraycopy(headerBytes, 0, fullContent, 0, headerBytes.length);
-    System.arraycopy(fileContents, 0, fullContent, headerBytes.length, fileContents.length);
+//     // Step 1: Read file content
+//     byte[] fileContents = Files.readAllBytes(file.toPath());
+//     String header = "blob " + fileContents.length + "\0";
+//     byte[] headerBytes = header.getBytes(StandardCharsets.UTF_8);
+//     byte[] fullContent = new byte[headerBytes.length + fileContents.length];
+//     System.arraycopy(headerBytes, 0, fullContent, 0, headerBytes.length);
+//     System.arraycopy(fileContents, 0, fullContent, headerBytes.length, fileContents.length);
 
-    // Step 2: Hash content and save blob
-    String sha1 = sha1Hex(fullContent); // Already defined in your file
-    String dir = sha1.substring(0, 2);
-    String fileSha = sha1.substring(2);
-    File blobFile = new File(".git/objects/" + dir + "/" + fileSha);
-    blobFile.getParentFile().mkdirs();
+//     // Step 2: Hash content and save blob
+//     String sha1 = sha1Hex(fullContent); // Already defined in your file
+//     String dir = sha1.substring(0, 2);
+//     String fileSha = sha1.substring(2);
+//     File blobFile = new File(".git/objects/" + dir + "/" + fileSha);
+//     blobFile.getParentFile().mkdirs();
 
-    try (DeflaterOutputStream out = new DeflaterOutputStream(new FileOutputStream(blobFile))) {
-        out.write(fullContent);
-    }
+//     try (DeflaterOutputStream out = new DeflaterOutputStream(new FileOutputStream(blobFile))) {
+//         out.write(fullContent);
+//     }
 
-    // Step 3: Update .git/index
-    File indexFile = new File(".git/index");
-    indexFile.getParentFile().mkdirs();
-    List<String> index = new ArrayList<>();
+//     // Step 3: Update .git/index
+//     File indexFile = new File(".git/index");
+//     indexFile.getParentFile().mkdirs();
+//     List<String> index = new ArrayList<>();
 
-    if (indexFile.exists()) {
-        index = Files.readAllLines(indexFile.toPath());
-        index = index.stream()
-                .filter(line -> !line.startsWith(filePath + " "))
-                .collect(Collectors.toList());
-    }
+//     if (indexFile.exists()) {
+//         index = Files.readAllLines(indexFile.toPath());
+//         index = index.stream()
+//                 .filter(line -> !line.startsWith(filePath + " "))
+//                 .collect(Collectors.toList());
+//     }
 
-    index.add(filePath + " " + sha1);
-    Files.write(indexFile.toPath(), index);
-    System.out.println("Staged: " + filePath);
-}
+//     index.add(filePath + " " + sha1);
+//     Files.write(indexFile.toPath(), index);
+//     System.out.println("Staged: " + filePath);
+// }
 
 
 }


### PR DESCRIPTION
Description:
_**1)This PR updates the commit-tree command to allow creation of initial commits (i.e., commits with no parent) by making the -p argument optional.**_
Problem:
Currently, running:
java Main commit-tree <tree-hash> -m "Initial commit"  
results in an exception:
IllegalArgumentException: Usage: java Main commit-tree -p -m  
This is because the program **enforces -p even for the initial commit, where no parent exists, leading to a failure.**

Proposed Solution:
**Check if the -p (parent) argument is provided.
If not provided, treat it as an initial commit and proceed without a parent.
If provided, proceed as usual and attach the given parent commit.**

This makes the command flexible and correct for:
Initial commits without a parent
Subsequent commits with a parent

Contributor:@Shrutit051
Fixes #13
